### PR TITLE
update document name

### DIFF
--- a/lib/libmemex/src/db/document.rs
+++ b/lib/libmemex/src/db/document.rs
@@ -3,7 +3,7 @@ use sea_orm::{ConnectionTrait, Set};
 use serde::Serialize;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Eq)]
-#[sea_orm(table_name = "documents")]
+#[sea_orm(table_name = "document")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i64,


### PR DESCRIPTION
Fixing a bug when trying to add to the database, but the table name "documents" DNE, but it's supposed to be "document".

> 2023-08-19T06:58:52.608119Z ERROR worker: [job=1] Unable to process embeddings: Execution Error: error returned from database: (code: 1) no such table: documents    