### PR TITLE
refactor: exposing endpoints in more consistent manner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,9 +415,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "base64ct"
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.6.0"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+checksum = "4c2f7349907b712260e64b0afe2f84692af14a454be26187d9df565c7f69266a"
 dependencies = [
  "memchr",
  "regex-automata 0.3.6",
@@ -2089,7 +2089,7 @@ checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
- "base64 0.21.2",
+ "base64 0.21.4",
  "bytecount",
  "clap",
  "fancy-regex",
@@ -2163,6 +2163,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
+ "tiktoken-rs",
  "tokenizers 0.14.0",
  "tokio",
  "url",
@@ -2361,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memex"
@@ -2717,7 +2718,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7899e6ad63d5c1dc6394785d625cadf560aaa5e606d6b709fd5cc6bbf1727f1"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
  "bytes",
  "dyn-clone",
  "lazy_static",
@@ -3380,7 +3381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
  "async-compression",
- "base64 0.21.2",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3573,7 +3574,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
 ]
 
 [[package]]
@@ -4191,7 +4192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca69bf415b93b60b80dc8fda3cb4ef52b2336614d8da2de5456cc942a110482"
 dependencies = [
  "atoi",
- "base64 0.21.2",
+ "base64 0.21.4",
  "bitflags 2.4.0",
  "byteorder",
  "bytes",
@@ -4234,7 +4235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0db2df1b8731c3651e204629dd55e52adbae0462fa1bdcbed56a2302c18181e"
 dependencies = [
  "atoi",
- "base64 0.21.2",
+ "base64 0.21.4",
  "bitflags 2.4.0",
  "byteorder",
  "chrono",
@@ -4469,12 +4470,12 @@ dependencies = [
 
 [[package]]
 name = "tiktoken-rs"
-version = "0.5.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf14cb08d8fda6e484c75ec2bfb6bcef48347d47abcd011fa9d56ee995a3da0"
+checksum = "f9ae5a3c24361e5f038af22517ba7f8e3af4099e30e78a3d56f86b48238fce9d"
 dependencies = [
  "anyhow",
- "base64 0.21.2",
+ "base64 0.21.4",
  "bstr",
  "fancy-regex",
  "lazy_static",
@@ -4744,7 +4745,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.2",
+ "base64 0.21.4",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5042,7 +5043,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
  "flate2",
  "log",
  "native-tls",

--- a/lib/api/src/endpoints/actions/filters.rs
+++ b/lib/api/src/endpoints/actions/filters.rs
@@ -36,10 +36,10 @@ fn extract(
 fn summarize(
     db: &DatabaseConnection,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-    warp::path!("action" / "summarize")
+    warp::path!("action" / "summarize" / "task")
         .and(warp::post())
         .and(with_db(db.clone()))
-        .and(json_body::<SummarizeRequest>(1024 * 1024))
+        .and(json_body::<SummarizeRequest>(1024 * 1024 * 10))
         .and_then(super::handlers::handle_summarize)
 }
 

--- a/lib/api/src/endpoints/actions/handlers.rs
+++ b/lib/api/src/endpoints/actions/handlers.rs
@@ -40,7 +40,7 @@ pub async fn handle_extract(
 
     Ok(warp::reply::json(&ApiResponse::success(
         &time.elapsed(),
-        Some(val),
+        Some(serde_json::json!({ "jsonResponse": val })),
     )))
 }
 

--- a/lib/api/src/endpoints/collections/handlers.rs
+++ b/lib/api/src/endpoints/collections/handlers.rs
@@ -59,7 +59,6 @@ pub async fn handle_search_docs(
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let time = std::time::Instant::now();
     let (_handle, embedder) = SentenceEmbedder::spawn(&ModelConfig::default());
-
     let vector_uri = std::env::var("VECTOR_CONNECTION").expect("VECTOR_CONNECTION env var not set");
     let client = match get_vector_storage(&vector_uri, &collection).await {
         Ok(client) => client,

--- a/lib/api/src/endpoints/tasks/handlers.rs
+++ b/lib/api/src/endpoints/tasks/handlers.rs
@@ -1,4 +1,7 @@
-use crate::{schema::TaskResult, ServerError};
+use crate::{
+    schema::{ApiResponse, TaskResult},
+    ServerError,
+};
 use libmemex::db::queue;
 use sea_orm::{DatabaseConnection, EntityTrait};
 
@@ -6,13 +9,20 @@ pub async fn handle_check_task(
     task_id: i64,
     db: DatabaseConnection,
 ) -> Result<impl warp::Reply, warp::Rejection> {
+    let time = std::time::Instant::now();
     let result = match queue::Entity::find_by_id(task_id).one(&db).await {
         Ok(res) => res,
         Err(err) => return Err(warp::reject::custom(ServerError::DatabaseError(err))),
     };
 
     match result {
-        Some(result) => Ok(warp::reply::json(&TaskResult::from(result))),
+        Some(result) => {
+            let result = TaskResult::from(result);
+            Ok(warp::reply::json(&ApiResponse::success(
+                &time.elapsed(),
+                Some(result),
+            )))
+        }
         None => Err(warp::reject::not_found()),
     }
 }

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -54,7 +54,7 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
 pub fn health_check() -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
 {
     let version = dotenv!("GIT_HASH");
-    warp::path("health")
+    warp::path!("api" / "health")
         .and(warp::get())
         .map(move || warp::reply::json(&json!({ "version": version })))
 }

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -8,7 +8,7 @@ use warp::{hyper::StatusCode, reject::Reject, Filter, Rejection, Reply};
 
 pub mod endpoints;
 pub mod schema;
-use schema::ErrorMessage;
+use schema::{ApiResponse, ErrorMessage};
 
 #[derive(Error, Debug)]
 pub enum ServerError {
@@ -42,10 +42,10 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
         message = "UNHANDLED_REJECTION".into();
     }
 
-    let json = warp::reply::json(&ErrorMessage {
+    let json = warp::reply::json(&ApiResponse::error(ErrorMessage {
         code: code.as_u16(),
         message,
-    });
+    }));
 
     Ok(warp::reply::with_status(json, code))
 }

--- a/lib/api/src/schema.rs
+++ b/lib/api/src/schema.rs
@@ -84,15 +84,17 @@ pub struct ApiResponse<T> {
     pub result: Option<T>,
 }
 
-impl<T> ApiResponse<T> {
-    pub fn error(elapsed: &Duration, error: ErrorMessage) -> ApiResponse<ErrorMessage> {
+impl<ErrorMessage> ApiResponse<ErrorMessage> {
+    pub fn error(error: ErrorMessage) -> ApiResponse<ErrorMessage> {
         ApiResponse {
-            time: elapsed.as_secs_f32(),
+            time: 0.0,
             status: ApiResponseStatus::Error,
             result: Some(error),
         }
     }
+}
 
+impl<T> ApiResponse<T> {
     pub fn success(elapsed: &Duration, result: Option<T>) -> Self {
         Self {
             time: elapsed.as_secs_f32(),

--- a/lib/api/src/schema.rs
+++ b/lib/api/src/schema.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use chrono::Utc;
 use libmemex::db;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// An API error serializable to JSON.
 #[derive(Serialize)]
@@ -44,11 +45,14 @@ pub struct SearchResult {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TaskResult {
     task_id: i64,
     collection: String,
     status: String,
     created_at: chrono::DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
 }
 
 impl From<db::queue::Model> for TaskResult {
@@ -58,6 +62,7 @@ impl From<db::queue::Model> for TaskResult {
             collection: value.collection,
             status: value.status.to_string(),
             created_at: value.created_at,
+            result: value.task_output,
         }
     }
 }
@@ -70,6 +75,7 @@ pub enum ApiResponseStatus {
 }
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiResponse<T> {
     /// Execution time in seconds
     pub time: f32,

--- a/lib/libmemex/Cargo.toml
+++ b/lib/libmemex/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = { workspace = true }
 strum = "0.25"
 strum_macros = "0.25"
 thiserror = "1.0"
+tiktoken-rs = "0.5.4"
 tokenizers = { version = "0.14", features = ["http"] }
 tokio = { workspace = true }
 url = "2.4.0"

--- a/lib/libmemex/src/db/queue.rs
+++ b/lib/libmemex/src/db/queue.rs
@@ -51,6 +51,7 @@ pub struct Model {
     pub id: i64,
     pub collection: String,
     pub payload: TaskPayload,
+    pub task_output: Option<Json>,
     /// Type of task
     pub task_type: TaskType,
     /// Task status.

--- a/lib/worker/src/lib.rs
+++ b/lib/worker/src/lib.rs
@@ -1,17 +1,14 @@
 use libmemex::db::create_connection_by_uri;
 use libmemex::db::queue::{self, check_for_jobs, Job, TaskType};
-use libmemex::db::{document, embedding};
-use libmemex::embedding::{ModelConfig, SentenceEmbedder};
-use libmemex::storage::{get_vector_storage, VectorData, VectorStorage};
-use libmemex::NAMESPACE;
+use libmemex::storage::get_vector_storage;
 use sea_orm::prelude::*;
-use sea_orm::Set;
-use sea_orm::TransactionTrait;
 use std::sync::{Arc, Mutex};
 use tokio::{
     sync::{broadcast, mpsc},
     time::Duration,
 };
+
+mod tasks;
 
 #[derive(Debug, Clone)]
 pub enum AppShutdown {
@@ -196,7 +193,7 @@ pub async fn run_workers(
                                         }
                                     };
 
-                                    if let Err(err) = _process_embeddings(db, client, &task).await {
+                                    if let Err(err) = tasks::process_embeddings(db, client, &task).await {
                                         log::error!("[job={}] Unable to process embeddings: {err}", task.id);
                                     }
 
@@ -219,70 +216,4 @@ pub async fn run_workers(
             }
         }
     }
-}
-
-async fn _process_embeddings(
-    db: DatabaseConnection,
-    client: VectorStorage,
-    task: &queue::Model,
-) -> anyhow::Result<()> {
-    let start = std::time::Instant::now();
-    let model_config = ModelConfig::default();
-
-    let (_handle, embedder) = SentenceEmbedder::spawn(&model_config);
-    log::info!("[job={}] generating embeddings", task.id);
-    let embeddings = embedder.encode(task.payload.content.clone()).await?;
-    log::info!(
-        "[job={}] created {} embeddings in {}ms",
-        task.id,
-        embeddings.len(),
-        start.elapsed().as_millis()
-    );
-
-    // Create a wrapper document w/ all the data from the task
-    let document = document::ActiveModel::from_task(task);
-    let document = document.insert(&db).await?;
-
-    let txn = db.begin().await?;
-    // Persist vectors to db & vector store
-    let mut vectors = Vec::new();
-    for (idx, embedding) in embeddings.iter().enumerate() {
-        // Create a unique identifier for this segment w/ the task_id & segment
-        let uuid = uuid::Uuid::new_v5(
-            &NAMESPACE,
-            format!("{}-{idx}", document.uuid.clone()).as_bytes(),
-        )
-        .to_string();
-
-        let mut new_seg = embedding::ActiveModel::new();
-        new_seg.uuid = Set(uuid.clone());
-        new_seg.document_id = Set(document.uuid.clone());
-        new_seg.segment = Set(idx as i64);
-        new_seg.content = Set(embedding.content.clone());
-        new_seg.vector = Set(embedding.vector.clone().into());
-        new_seg.insert(&txn).await?;
-
-        vectors.push(VectorData {
-            _id: uuid.clone(),
-            document_id: document.uuid.clone(),
-            text: embedding.content.clone(),
-            segment_id: idx,
-            vector: embedding.vector.clone(),
-        });
-    }
-
-    if let Err(err) = client.add_vectors(vectors).await {
-        log::error!("[job={}] Unable to upsert points: {err}", task.id);
-    } else {
-        log::info!("[job={}] Persisted embeddings", task.id);
-    }
-    txn.commit().await?;
-    let _ = queue::mark_done(&db, task.id).await;
-    log::info!(
-        "[job={}] job finished in {}ms",
-        task.id,
-        start.elapsed().as_millis()
-    );
-
-    Ok(())
 }

--- a/lib/worker/src/tasks.rs
+++ b/lib/worker/src/tasks.rs
@@ -1,0 +1,71 @@
+use libmemex::db::{document, embedding, queue};
+use libmemex::embedding::{ModelConfig, SentenceEmbedder};
+use libmemex::storage::{VectorData, VectorStorage};
+use libmemex::NAMESPACE;
+use sea_orm::{prelude::*, Set, TransactionTrait};
+
+pub async fn process_embeddings(
+    db: DatabaseConnection,
+    client: VectorStorage,
+    task: &queue::Model,
+) -> anyhow::Result<()> {
+    let start = std::time::Instant::now();
+    let model_config = ModelConfig::default();
+
+    let (_handle, embedder) = SentenceEmbedder::spawn(&model_config);
+    log::info!("[job={}] generating embeddings", task.id);
+    let embeddings = embedder.encode(task.payload.content.clone()).await?;
+    log::info!(
+        "[job={}] created {} embeddings in {}ms",
+        task.id,
+        embeddings.len(),
+        start.elapsed().as_millis()
+    );
+
+    // Create a wrapper document w/ all the data from the task
+    let document = document::ActiveModel::from_task(task);
+    let document = document.insert(&db).await?;
+
+    let txn = db.begin().await?;
+    // Persist vectors to db & vector store
+    let mut vectors = Vec::new();
+    for (idx, embedding) in embeddings.iter().enumerate() {
+        // Create a unique identifier for this segment w/ the task_id & segment
+        let uuid = uuid::Uuid::new_v5(
+            &NAMESPACE,
+            format!("{}-{idx}", document.uuid.clone()).as_bytes(),
+        )
+        .to_string();
+
+        let mut new_seg = embedding::ActiveModel::new();
+        new_seg.uuid = Set(uuid.clone());
+        new_seg.document_id = Set(document.uuid.clone());
+        new_seg.segment = Set(idx as i64);
+        new_seg.content = Set(embedding.content.clone());
+        new_seg.vector = Set(embedding.vector.clone().into());
+        new_seg.insert(&txn).await?;
+
+        vectors.push(VectorData {
+            _id: uuid.clone(),
+            document_id: document.uuid.clone(),
+            text: embedding.content.clone(),
+            segment_id: idx,
+            vector: embedding.vector.clone(),
+        });
+    }
+
+    if let Err(err) = client.add_vectors(vectors).await {
+        log::error!("[job={}] Unable to upsert points: {err}", task.id);
+    } else {
+        log::info!("[job={}] Persisted embeddings", task.id);
+    }
+    txn.commit().await?;
+    let _ = queue::mark_done(&db, task.id).await;
+    log::info!(
+        "[job={}] job finished in {}ms",
+        task.id,
+        start.elapsed().as_millis()
+    );
+
+    Ok(())
+}

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -3,6 +3,7 @@ pub use sea_orm_migration::prelude::*;
 mod m20220101_000001_create_table;
 mod m20230919_115012_create_embedding_table;
 mod m20230920_114744_add_task_type_column;
+mod m20231002_201128_add_output_column;
 
 pub struct Migrator;
 
@@ -13,6 +14,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20220101_000001_create_table::Migration),
             Box::new(m20230919_115012_create_embedding_table::Migration),
             Box::new(m20230920_114744_add_task_type_column::Migration),
+            Box::new(m20231002_201128_add_output_column::Migration),
         ]
     }
 }

--- a/migration/src/m20231002_201128_add_output_column.rs
+++ b/migration/src/m20231002_201128_add_output_column.rs
@@ -1,0 +1,37 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if !manager.has_column("queue", "task_output").await? {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(Queue::Table)
+                        .add_column(
+                            ColumnDef::new(Queue::TaskOutput)
+                                .json()
+                                .null(),
+                        )
+                        .to_owned(),
+                )
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}
+
+/// Learn more at https://docs.rs/sea-query#iden
+#[derive(Iden)]
+enum Queue {
+    Table,
+    TaskOutput
+}

--- a/migration/src/m20231002_201128_add_output_column.rs
+++ b/migration/src/m20231002_201128_add_output_column.rs
@@ -11,11 +11,7 @@ impl MigrationTrait for Migration {
                 .alter_table(
                     Table::alter()
                         .table(Queue::Table)
-                        .add_column(
-                            ColumnDef::new(Queue::TaskOutput)
-                                .json()
-                                .null(),
-                        )
+                        .add_column(ColumnDef::new(Queue::TaskOutput).json().null())
                         .to_owned(),
                 )
                 .await?;
@@ -33,5 +29,5 @@ impl MigrationTrait for Migration {
 #[derive(Iden)]
 enum Queue {
     Table,
-    TaskOutput
+    TaskOutput,
 }


### PR DESCRIPTION
- Attach API endpoint to `/api/<endpoints>`
- Keep track of summarize results.
- Return any task outputs as part of the task response.